### PR TITLE
Update for Front-End Moderation of Reviews

### DIFF
--- a/assets/css/bgr-reviews.css
+++ b/assets/css/bgr-reviews.css
@@ -268,6 +268,10 @@ ul.bupr-group-main li.bupr-group .bupr-meta {
     width: 100%;
 }
 
+a.remove-review-button {position: relative; left: 1em;}
+a.approve-review-button {position: absolute; left: 12em;}
+.bgr-row.item-list.review-status-draft {background-color: #E9E9E9;}
+
 .bgr-multi-review {
     margin: 15px;
 }

--- a/assets/js/bgr-front.js
+++ b/assets/js/bgr-front.js
@@ -79,6 +79,22 @@ jQuery(document).ready(function (e) {
       }
     );
   });
+	
+  // Approve review
+  jQuery(document).on("click", ".approve-review-button", function () {
+    var approve_review_id = jQuery(this).next().val();
+    jQuery.post(
+      ajaxurl,
+      {
+        action: "bgr_approve_review",
+        nonce: bgr_front_js_object.wbcom_nonce,
+        approve_review_id: approve_review_id,
+      },
+      function (response) {
+        location.reload();
+      }
+    );
+  });	
 
   // Remove error mark on change of input field
   jQuery("#form-group-id").on("change", function () {

--- a/includes/bgr-ajax.php
+++ b/includes/bgr-ajax.php
@@ -44,6 +44,8 @@ if ( ! class_exists( 'BGR_AJAX' ) ) {
 			add_action( 'wp_ajax_nopriv_bgr_deny_review', array( $this, 'bgr_deny_review' ) );
 			add_action( 'wp_ajax_bgr_remove_review', array( $this, 'bgr_remove_review' ) );
 			add_action( 'wp_ajax_nopriv_bgr_remove_review', array( $this, 'bgr_remove_review' ) );
+			add_action( 'wp_ajax_bgr_approve_review', array( $this, 'bgr_approve_review' ) );
+			add_action( 'wp_ajax_nopriv_bgr_approve_review', array( $this, 'bgr_approve_review' ) );			
 			add_action( 'wp_ajax_bgr_submit_review', array( $this, 'bgr_submit_review' ) );
 			add_action( 'wp_ajax_nopriv_bgr_submit_review', array( $this, 'bgr_submit_review' ) );
 
@@ -166,6 +168,8 @@ if ( ! class_exists( 'BGR_AJAX' ) ) {
 						if ( groups_is_user_admin( $member_id, bp_get_group_id() ) ) :
 							$html .= '<div class="remove-review generic-button">';
 							$html .= '<a class="remove-review-button">' . __( 'Delete', 'bp-group-reviews' ) . '</a><input type="hidden" name="remove_review_id" value="' . esc_attr( $post->ID ) . '"></div>';
+							$html .= '<div class="approve-review generic-button">';
+							$html .= '<a class="approve-review-button">' . __( 'Approve', 'bp-group-reviews' ) . '</a><input type="hidden" name="approve_review_id" value="' . esc_attr( $post->ID ) . '"></div>';					
 						endif;
 						$html .= '</div><div class="clear"></div></div>';
 				endwhile;
@@ -819,6 +823,38 @@ if ( ! class_exists( 'BGR_AJAX' ) ) {
 			die;
 		}
 
+		/**
+		 * Mark Group Reviews as Approved from the Front End
+		 *
+		 * @since 3.2.3
+		 */
+		public function bgr_approve_review() {
+
+			$nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+
+			if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'ajax-nonce' ) ) {
+				$error = new WP_Error( '001', 'Nonce not verified!', 'Some information' );
+				wp_send_json_error( $error );
+			}
+
+			if ( ! is_user_logged_in() ) return false;
+
+			$post_id 	 = isset( $_POST['approve_review_id'] ) ? sanitize_text_field( wp_unslash( $_POST['approve_review_id'] ) ) : '';
+			$review_post = array(
+				'ID'           => $post_id,
+				'post_status' => 'publish',
+			);
+
+			wp_update_post( $review_post );
+			
+			do_action( 'gamipress_bp_group_review', $author_id );
+			
+			echo 'review-approved-successfully';
+
+			die;
+
+		}		
+		
 	}
 	new BGR_AJAX();
 }


### PR DESCRIPTION
Allows Group & Site Admins to view Pending Group Reviews from the Reviews Tab (Pending Reviews only Visible to Group & Site Admins). Adds extra button for Approving a Review, next to the existing Deny Button. Also adds a conditional CSS Class to the Review Wrapper HTML, so that you can style the Pending Reviews separately from those that have been approved. (Add a different background color for example) 